### PR TITLE
Fixed the alignment of the Transactions table header

### DIFF
--- a/raccoin_ui/ui/transactions.slint
+++ b/raccoin_ui/ui/transactions.slint
@@ -16,8 +16,9 @@ import { UiTransactionType, UiTransaction } from "./structs.slint";
 component TransactionsHeader inherits TableHeader {
     Rectangle {
         height: date-text.preferred-height;
+        width: date-time-cell.preferred-width;
 
-        DateTimeCell {
+        date-time-cell := DateTimeCell {
             padding-left: 0;
             visible: false; // only used for alignment purposes
         }


### PR DESCRIPTION
Was broken in similar way to the Capital Gains report headers in commit bb2cf20e39160e7ec00b80bbe06f58fe2938e102.