### PR TITLE
Added "Update Price History" button

### DIFF
--- a/raccoin_ui/ui/global.slint
+++ b/raccoin_ui/ui/global.slint
@@ -41,6 +41,8 @@ export global Facade {
     callback add-source(int);
     callback remove-source(int,int);
 
+    callback update-price-history();
+
     callback ignore-currency(string);
 
     // params: (blockchain, tx_hash)

--- a/raccoin_ui/ui/portfolio.slint
+++ b/raccoin_ui/ui/portfolio.slint
@@ -51,6 +51,10 @@ export component Portfolio inherits Rectangle {
                     text: "Close";
                     clicked => { Facade.close-portfolio(); }
                 }
+                Button {
+                    text: "Update Price History";
+                    clicked => { Facade.update-price-history(); }
+                }
                 height: self.preferred-height;
                 width: self.preferred-width;
             }

--- a/src/base.rs
+++ b/src/base.rs
@@ -497,12 +497,25 @@ pub(crate) fn load_transactions_from_json(input_path: &Path) -> Result<Vec<Trans
     Ok(transactions)
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Copy)]
 pub(crate) struct PricePoint {
     pub timestamp: NaiveDateTime,
     pub price: Decimal,
 }
 
+impl PartialOrd for PricePoint {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PricePoint {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.timestamp.cmp(&other.timestamp)
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub(crate) struct PriceHistory {
     prices: HashMap<String, Vec<PricePoint>>,
 }
@@ -518,8 +531,21 @@ impl PriceHistory {
         Self { prices }
     }
 
-    pub(crate) fn insert_price_points(&mut self, currency: String, price_points: Vec<PricePoint>) {
+    pub(crate) fn empty() -> Self {
+        Self {
+            prices: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn set_price_points(&mut self, currency: String, price_points: Vec<PricePoint>) {
         self.prices.insert(currency, price_points);
+    }
+
+    pub(crate) fn add_price_points(&mut self, currency: String, price_points: Vec<PricePoint>) {
+        let points = self.prices.entry(currency).or_default();
+        for price_point in price_points {
+            points.insert(points.partition_point(|&p| p < price_point), price_point);
+        }
     }
 
     // todo: would be nice to expose the accuracy in the UI
@@ -529,6 +555,17 @@ impl PriceHistory {
             _ => {
                 self.prices.get(currency).and_then(|price_points| {
                     estimate_price(timestamp, price_points).map(|(price, _)| price)
+                })
+            }
+        }
+    }
+
+    pub(crate) fn estimate_price_with_accuracy(&self, timestamp: NaiveDateTime, currency: &str) -> Option<(Decimal, Duration)> {
+        match currency {
+            "EUR" => Some((Decimal::ONE, Duration::zero())),
+            _ => {
+                self.prices.get(currency).and_then(|price_points| {
+                    estimate_price(timestamp, price_points)
                 })
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ mod trezor;
 
 use anyhow::{Context, Result, anyhow};
 use base::{Operation, Amount, Transaction, cmc_id, PriceHistory};
-use chrono::{Duration, Datelike, Utc, TimeZone, Local};
+use chrono::{Duration, Datelike, Utc, TimeZone, Local, NaiveDateTime};
 use directories::ProjectDirs;
 use raccoin_ui::*;
 use fifo::{FIFO, CapitalGain};
@@ -272,6 +272,8 @@ struct Portfolio {
     #[serde(default)]
     wallets: Vec<Wallet>,
     #[serde(default)]
+    price_history: PriceHistory,
+    #[serde(default)]
     ignored_currencies: Vec<String>,
     #[serde(default)]
     merge_consecutive_trades: bool,
@@ -380,7 +382,6 @@ struct App {
     portfolio: Portfolio,
     transactions: Vec<Transaction>,
     reports: Vec<TaxReport>,
-    price_history: PriceHistory,
 
     transaction_filters: Vec<TransactionFilter>,
 
@@ -393,8 +394,6 @@ struct App {
 
 impl App {
     fn new() -> Self {
-        let mut price_history = PriceHistory::new();
-
         let project_dirs = ProjectDirs::from("org", "raccoin",  "Raccoin");
         let state = project_dirs.as_ref().and_then(|dirs| {
             let config_dir = dirs.config_local_dir();
@@ -409,7 +408,6 @@ impl App {
             portfolio: Portfolio::default(),
             transactions: Vec::new(),
             reports: Vec::new(),
-            price_history,
 
             transaction_filters: Vec::default(),
 
@@ -488,7 +486,7 @@ impl App {
     }
 
     fn refresh_transactions(&mut self) {
-        self.transactions = load_transactions(&mut self.portfolio, &self.price_history).unwrap_or_default();
+        self.transactions = load_transactions(&mut self.portfolio).unwrap_or_default();
         self.reports = calculate_tax_reports(&mut self.transactions);
     }
 
@@ -620,6 +618,7 @@ pub(crate) fn export_all_to(app: &App, output_path: &Path) -> Result<()> {
             cost: rounded_to_cent(report.short_term_cost),
             gains: rounded_to_cent(report.short_term_proceeds - report.short_term_cost),
         })?;
+
         let year = if report.year == 0 { "all_time".to_owned() } else { report.year.to_string() };
         let path = output_path.join(format!("{}_report_summary.csv", year));
         save_summary_to_csv(report, &path)?;
@@ -630,7 +629,7 @@ pub(crate) fn export_all_to(app: &App, output_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn load_transactions(portfolio: &mut Portfolio, price_history: &PriceHistory) -> Result<Vec<Transaction>> {
+fn load_transactions(portfolio: &mut Portfolio) -> Result<Vec<Transaction>> {
     let (wallets, ignored_currencies) = (&mut portfolio.wallets, &portfolio.ignored_currencies);
     let mut transactions = Vec::new();
 
@@ -805,7 +804,7 @@ fn load_transactions(portfolio: &mut Portfolio, price_history: &PriceHistory) ->
     }
 
     match_send_receive(&mut transactions);
-    estimate_transaction_values(&mut transactions, price_history);
+    estimate_transaction_values(&mut transactions, &portfolio.price_history);
 
     Ok(transactions)
 }
@@ -1031,6 +1030,58 @@ fn estimate_transaction_values(transactions: &mut Vec<Transaction>, price_histor
 
     // Estimate the value for all transactions
     transactions.iter_mut().for_each(estimate_transaction_value);
+}
+
+async fn download_price_history(transactions: Vec<Transaction>) -> Result<PriceHistory> {
+    let mut price_history = PriceHistory::empty();
+
+    async fn ensure_price_point(price_history: &mut PriceHistory, timestamp: NaiveDateTime, currency: &str) {
+        // If there is already a price point within 1 hour, we don't need to download new price points
+        if let Some((_, accuracy)) = price_history.estimate_price_with_accuracy(timestamp, currency) {
+            if accuracy <= Duration::hours(1) {
+                return;
+            }
+        }
+
+        let price_points = coinmarketcap::download_price_points(timestamp, currency).await;
+        match price_points {
+            Ok(price_points) => {
+                price_history.add_price_points(currency.into(), price_points);
+            }
+            Err(e) => {
+                println!("warning: failed to download price points for {:}: {:?}", currency, e);
+            }
+        }
+    }
+
+    for tx in transactions.iter().rev() {
+        match tx.incoming_outgoing() {
+            (Some(incoming), Some(outgoing)) => {
+                if !incoming.is_fiat() {
+                    ensure_price_point(&mut price_history, tx.timestamp, &incoming.currency).await;
+                }
+                if !outgoing.is_fiat() {
+                    ensure_price_point(&mut price_history, tx.timestamp, &outgoing.currency).await;
+                }
+            }
+            (Some(amount), None) |
+            (None, Some(amount)) => {
+                if !amount.is_fiat() {
+                    ensure_price_point(&mut price_history, tx.timestamp, &amount.currency).await;
+                }
+            }
+            (None, None) => {}
+        };
+
+        match &tx.fee {
+            Some(amount) => {
+                ensure_price_point(&mut price_history, tx.timestamp, &amount.currency).await;
+            }
+            None => {}
+        };
+    }
+
+    Ok(price_history)
 }
 
 fn calculate_tax_reports(transactions: &mut Vec<Transaction>) -> Vec<TaxReport> {
@@ -1490,7 +1541,7 @@ fn ui_set_portfolio(app: &App) {
                 return None
             }
 
-            let current_price = app.price_history.estimate_price(now, &currency.currency);
+            let current_price = app.portfolio.price_history.estimate_price(now, &currency.currency);
             let current_value = current_price.map(|price| currency.balance_end * price).unwrap_or(Decimal::ZERO);
             let unrealized_gain = current_value - currency.cost_end;
             let roi = if currency.cost_end > Decimal::ZERO { Some(unrealized_gain / currency.cost_end * Decimal::ONE_HUNDRED) } else { None };
@@ -1531,6 +1582,9 @@ fn ui_set_portfolio(app: &App) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // coinmarketcap::download_price_history("ETH").await?;
+    // coinmarketcap::download_price_history("BTC").await?;
+
     let mut app = App::new();
 
     // Load portfolio from command-line or from previous application state
@@ -1859,6 +1913,34 @@ async fn main() -> Result<()> {
                         // todo: show error in UI
                         println!("Error syncing transactions: {}", e);
                     }
+                }
+            }).unwrap();
+        }
+    });
+
+    facade.on_update_price_history({
+        let app = app.clone();
+
+        move || {
+            let app = app.clone();
+
+            slint::spawn_local(async move {
+                let transactions = app.borrow().transactions.clone();
+                let price_history = tokio::task::spawn(download_price_history(transactions)).await.unwrap();
+
+                let mut app = app.borrow_mut();
+
+                match price_history {
+                    Ok(price_history) => {
+                        app.portfolio.price_history = price_history;
+                        app.refresh_transactions();
+                        app.refresh_ui();
+                        app.save_portfolio(None);
+                    }
+                    Err(e) => {
+                        // todo: show error in UI
+                        println!("Error updating price history: {}", e);
+                    },
                 }
             }).unwrap();
         }


### PR DESCRIPTION
This change is not entirely polished. The price history is now stored inside the portfolio, so that it is persistent. However, it consumes way too much space there since way more price points are being downloaded than necessary.

Probably the needed price points should just be stored on each transaction, which implies storing all transactions in the portfolio after importing them from a CSV file. Or maybe we should cache the price history in CSV files outside of the project.