### PR TITLE
Add universal binary support for macOS builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,21 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
-    - run: cargo build --verbose --release
+    - name: Install targets
+      run: |
+        rustup target add x86_64-apple-darwin
+        rustup target add aarch64-apple-darwin
+    - name: Build Intel binary
+      run: cargo build --verbose --release --target x86_64-apple-darwin
+    - name: Build ARM64 binary
+      run: cargo build --verbose --release --target aarch64-apple-darwin
+    - name: Create universal binary
+      run: |
+        mkdir -p target/release
+        lipo -create \
+          target/x86_64-apple-darwin/release/raccoin \
+          target/aarch64-apple-darwin/release/raccoin \
+          -output target/release/raccoin
     - run: cargo install cargo-packager --locked
     - run: cargo packager --release
     - run: ditto -c -k --sequesterRsrc --keepParent target/release/Raccoin.app Raccoin.app.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 windows_exe_info = "0.5"
 
 [package.metadata.packager]
-before-packaging-command = "cargo build --release"
 identifier = "org.raccoin.Raccoin"
 product-name = "Raccoin"
 description = "Crypto Portfolio and Tax Reporting Tool"


### PR DESCRIPTION
Build for both Intel and ARM64 architectures and combine into a single universal binary using lipo